### PR TITLE
chore: bump version to 0.3.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "climonad",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climonad",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climonad",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A high-performance, low-overhead library for building modern command-line interfaces in Node.js",
   "main": "./dist/main.cjs",
   "type": "module",


### PR DESCRIPTION
This pull request includes a version update for the `climonad` library in the `package.json` file. The version has been incremented from `0.2.0` to `0.3.0`, indicating a new release with potential new features, improvements, or fixes.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.2.0` to `0.3.0`.